### PR TITLE
Fix missing passwords

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ before_install:
 before_script:
   - export PATH="/usr/lib/postgresql/11/bin:$PATH"
   - diesel database setup --locked-schema --migration-dir=src/diesel_cfg/migrations/
-  - rustup component add rustfmt --toolchain stable
-  - rustup component add clippy --toolchain stable
+  - rustup component add rustfmt --toolchain nightly 
+  - rustup component add clippy --toolchain nightly
 
 
 scipt:

--- a/src/apps/user/views.rs
+++ b/src/apps/user/views.rs
@@ -19,7 +19,8 @@ use crate::{
 use tera::{self, Context};
 
 use actix_web::{
-    error::ErrorInternalServerError, http, web, Error, HttpRequest, HttpResponse, Result,
+    error::{ErrorForbidden, ErrorInternalServerError},
+    http, web, Error, HttpRequest, HttpResponse, Result,
 };
 use serde_json::json;
 use validator::Validate;
@@ -235,7 +236,7 @@ pub async fn login(user: web::Json<SignInUser<'_>>) -> Result<HttpResponse, Erro
             if !usr
                 .verify_pass(user.get_password())
                 .await
-                .map_err(ErrorInternalServerError)?
+                .map_err(ErrorForbidden)?
             {
                 let status = http::StatusCode::UNAUTHORIZED;
                 return Ok(HttpResponse::build(status)


### PR DESCRIPTION
    The password is an option which was previously
    being unwrapped.
    This eliminates potential panicks for oauth
    registered accounts.

**NOTE**: Build fails from travis ci rustup version `rustup 1.22.1` not having `rustfmt` in the `nightly-build`